### PR TITLE
Support image styling

### DIFF
--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -105,6 +105,10 @@ class LinkPreviewGenerator extends StatefulWidget {
   /// Pass empty function to disable tap.
   final void Function()? onTap;
 
+  /// Customize the opacity of the image.
+  /// Defaults to `1.0`.
+  final double opacity;
+
   /// Creates [LinkPreviewGenerator]
   const LinkPreviewGenerator({
     Key? key,
@@ -132,6 +136,7 @@ class LinkPreviewGenerator extends StatefulWidget {
     this.borderRadius = 12.0,
     this.boxShadow,
     this.removeElevation = false,
+    this.opacity = 1.0,
   }) : super(key: key);
 
   @override
@@ -270,6 +275,7 @@ class _LinkPreviewGeneratorState extends State<LinkPreviewGenerator> {
                 isIcon: isIcon,
                 bgColor: widget.backgroundColor,
                 radius: widget.borderRadius,
+                opacity: widget.opacity,
               )
             : LinkViewLarge(
                 key: widget.key ?? Key(widget.link.toString()),
@@ -290,6 +296,7 @@ class _LinkPreviewGeneratorState extends State<LinkPreviewGenerator> {
                 isIcon: isIcon,
                 bgColor: widget.backgroundColor,
                 radius: widget.borderRadius,
+                opacity: widget.opacity,
               ),
       ),
     );

--- a/lib/src/widgets/link_view_large.dart
+++ b/lib/src/widgets/link_view_large.dart
@@ -20,6 +20,7 @@ class LinkViewLarge extends StatelessWidget {
   final String title;
   final TextStyle? titleTextStyle;
   final String url;
+  final double opacity;
 
   const LinkViewLarge({
     Key? key,
@@ -41,6 +42,7 @@ class LinkViewLarge extends StatelessWidget {
     this.isIcon = false,
     this.bgColor,
     this.radius,
+    this.opacity = 1.0,
   }) : super(key: key);
 
   @override
@@ -86,6 +88,7 @@ class LinkViewLarge extends StatelessWidget {
                                       topRight: Radius.circular(12),
                                     ),
                               image: DecorationImage(
+                                opacity: opacity,
                                 image: NetworkImage(imageUri),
                                 fit: isIcon ? BoxFit.contain : graphicFit,
                               ),

--- a/lib/src/widgets/link_view_small.dart
+++ b/lib/src/widgets/link_view_small.dart
@@ -20,6 +20,7 @@ class LinkViewSmall extends StatelessWidget {
   final String title;
   final TextStyle? titleTextStyle;
   final String url;
+  final double opacity;
 
   const LinkViewSmall({
     Key? key,
@@ -41,6 +42,7 @@ class LinkViewSmall extends StatelessWidget {
     this.isIcon = false,
     this.bgColor,
     this.radius,
+    this.opacity = 1.0,
   }) : super(key: key);
 
   @override
@@ -80,6 +82,7 @@ class LinkViewSmall extends StatelessWidget {
                             margin: const EdgeInsets.only(right: 5),
                             decoration: BoxDecoration(
                               image: DecorationImage(
+                                opacity: opacity,
                                 image: NetworkImage(imageUri),
                                 fit: isIcon ? BoxFit.contain : graphicFit,
                               ),


### PR DESCRIPTION
This PR is related to thunder-app/thunder#609. It adds the ability to set the link preview image opacity when constructing the widget. (Note that this is a property of the image and not an `Opacity` widget.)